### PR TITLE
fix compile error on go get

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -92,7 +92,7 @@ func withFont(input, fontName string) {
 	buf := new(bytes.Buffer)
 	figure.Write(buf, myFigure)
 
-	seed := int(rand.Int31n(256))
+	seed := int64(rand.Int31n(256))
 	l := rainbow.Light{
 		Reader: buf,
 		Writer: os.Stdout,


### PR DESCRIPTION
build break found by [gopkgs.io](https://gopkgs.io)

example build log:
https://gopkgs.io/builds/20181015-222444-d25e0f5a